### PR TITLE
Fix empty Azure DevOps pipeline

### DIFF
--- a/cloud_security/v17/pipelines/azure-devops/terraform-pipeline.yml
+++ b/cloud_security/v17/pipelines/azure-devops/terraform-pipeline.yml
@@ -1,0 +1,26 @@
+trigger:
+- main
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+- task: terraform-installer@1
+  inputs:
+    terraformVersion: '1.5.7'
+
+- script: terraform -chdir=terraform init
+  displayName: 'Terraform Init'
+
+- script: terraform -chdir=terraform fmt -check
+  displayName: 'Terraform Format'
+
+- script: terraform -chdir=terraform validate
+  displayName: 'Terraform Validate'
+
+- script: terraform -chdir=terraform plan -out=tfplan
+  displayName: 'Terraform Plan'
+
+- script: terraform -chdir=terraform apply -auto-approve tfplan
+  displayName: 'Terraform Apply'
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')


### PR DESCRIPTION
## Summary
- add a missing Azure DevOps pipeline for Terraform

## Testing
- `python -m py_compile cloud_security/v17/functions/remediation-tagging/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6842fb93b0dc83309c0c999db4e0d70d